### PR TITLE
Updating for UE4.27/5 and BP Interface

### DIFF
--- a/Source/BYGRichText/Private/BYGRichTextModule.cpp
+++ b/Source/BYGRichText/Private/BYGRichTextModule.cpp
@@ -89,6 +89,11 @@ void FBYGRichTextModule::OnPostEngineInit()
 	}
 }
 
+FString FBYGRichTextModule::GetReferencerName() const
+{
+	return TEXT("FBYGRichTextModule");
+}
+
 void FBYGRichTextModule::AddReferencedObjects( FReferenceCollector& Collector )
 {
 	Collector.AddReferencedObject( FallbackStylesheet );

--- a/Source/BYGRichText/Private/Widget/BYGRichTextBlock.cpp
+++ b/Source/BYGRichText/Private/Widget/BYGRichTextBlock.cpp
@@ -135,7 +135,7 @@ void UBYGRichTextBlock::SetText( const FText& InText )
 {
 	Text = InText;
 
-	RebuildWidget();
+	RebuildContents();
 }
 
 void UBYGRichTextBlock::CreateDecorators( TArray< TSharedRef< class ITextDecorator > >& OutDecorators )

--- a/Source/BYGRichText/Public/BYGRichTextModule.h
+++ b/Source/BYGRichText/Public/BYGRichTextModule.h
@@ -16,6 +16,7 @@ public:
 
 	// Begin FGCObject overrides
 	virtual void AddReferencedObjects( FReferenceCollector& Collector ) override;
+	virtual FString GetReferencerName() const override;
 	// End FGCObject overrides
 
 	const FSlateBrush* GetIconBrush( const FString& Path, const FVector2D& MaxSize );

--- a/Source/BYGRichText/Public/Widget/BYGRichTextBlock.h
+++ b/Source/BYGRichText/Public/Widget/BYGRichTextBlock.h
@@ -39,9 +39,11 @@ public:
 	virtual void ReleaseSlateResources( bool bReleaseChildren ) override;
 	// End of UVisual interface
 
+	UFUNCTION(BlueprintCallable)
 	void SetText( const FText& InText );
-	inline FText GetText() { return Text; }
 
+	UFUNCTION(BlueprintPure)
+	FText GetText() const { return Text; }
 
 	// TODO should store unmodifiable rich text stylesheet instance in the module?
 	const UBYGRichTextStylesheet* GetRichTextStylesheet() const;


### PR DESCRIPTION
Fixed:
- SetText not updating contents
- GC CollectReferences warning due to BYGRichTextModule not implementing the new FGCObject interface

Added:
- Blueprint interface for SetText/GetText